### PR TITLE
Remove output SQL from tmp directory

### DIFF
--- a/psql-gcp-backup.sh
+++ b/psql-gcp-backup.sh
@@ -19,7 +19,9 @@ if [ "$PSQL_USER" == "" ]; then
     PSQL_USER=postgres
 fi
 
-if [[ $(psql -U "$PSQL_USER" -lqt | cut -d \| -f 1 | grep -qw "$DB_NAME") != "0" ]]
+$(psql -U "$PSQL_USER" -lqt | cut -d \| -f 1 | grep -qw "$DB_NAME")
+EXISTS=$?
+if [[ "$EXISTS" != 0 ]]
 then
     echo "Database does not exist"
     exit 1

--- a/psql-gcp-backup.sh
+++ b/psql-gcp-backup.sh
@@ -29,3 +29,5 @@ fi
 
 pg_dump -U postgres "$DB_NAME" > "/tmp/$DB_NAME-dump_$DATE.sql"
 gsutil -m -h "Cache-Control:no-cache" cp -r "/tmp/$DB_NAME-dump_$DATE.sql" "gs://$BUCKET/"
+
+rm /tmp/$DB_NAME-dump_$DATE.sql


### PR DESCRIPTION
Rudimentary cleanup system to remove output SQL from tmp directory to stop system from disk flooding.