### PR TITLE
Add a script to back up Aerospike namespaces to GCS

### DIFF
--- a/aerospike-gcp-backup/README.md
+++ b/aerospike-gcp-backup/README.md
@@ -26,6 +26,6 @@ Update the permissions to allow for execution
 `chmod +x aerospike-gcp-backup.sh`
 
 Run the script
-`./aerospike-gcp-backup.sh <namespace> <bucket name> <host>
+`NAMESPACE=<namespace> BUCKET=<bucket name> HOST=<host> ./aerospike-gcp-backup.sh`
 
 *note: if no host is passed localhost is assumed 

--- a/aerospike-gcp-backup/README.md
+++ b/aerospike-gcp-backup/README.md
@@ -1,0 +1,31 @@
+# Aerospike Backup to GCP
+
+## TL;DR
+A script for backing up Aerospike namespaces on GCP, only once content has changed,
+and compressed for reduced size.
+
+## Prerequisites
+
+### Create the bucket
+
+The bucket will need to exist before running the script. Instructions to create
+a bucket are listed on [GCP Storage](https://cloud.google.com/storage/docs/creating-buckets).
+
+### Aerospike tools
+
+This script relies on asbackup and pg_dump being installed on the path. If you're
+running this from a machine that is not an Aerospike server, ensure these tools are installed.
+
+## Usage
+
+Download the script to where you want to run it by cloning the repo or just
+getting the file.
+`wget https://raw.githubusercontent.com/fresh8/script-repo/master/aerospike-gcp-backup/aerospike-gcp-backup.sh`
+
+Update the permissions to allow for execution
+`chmod +x aerospike-gcp-backup.sh`
+
+Run the script
+`./aerospike-gcp-backup.sh <namespace> <bucket name> <host>
+
+*note: if no host is passed localhost is assumed 

--- a/aerospike-gcp-backup/aerospike-gcp-backup.sh
+++ b/aerospike-gcp-backup/aerospike-gcp-backup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+DATE=$(date +%Y%m%d_%H%M)
+NAMESPACE=$1
+BUCKET=$2
+HOST=$3
+
+if [ "$NAMESPACE" == "" ]; then
+    echo "Namespace required"
+    exit 1
+fi
+if [ "$BUCKET" == "" ]; then
+    echo "Namespace required"
+    exit 1
+fi
+if [ "$HOST" == "" ]; then
+    HOST=localhost
+fi
+
+OUTPUT_FILE="/tmp/$DB_NAME-dump_$DATE.asb"
+
+asbackup --host $HOST --namespace $NAMESPACE --output-file - > $OUTPUT_FILE
+LAST_MD5_FILE="/tmp/$DB_NAME-dump-md5"
+if [ -f "$LAST_MD5_FILE" ]; then
+  CURRENT_MD5=$(md5sum $OUTPUT_FILE | awk '{ print $1 }')
+  LAST_MD5=$(cat "$LAST_MD5_FILE")
+
+  if [ "$CURRENT_MD5" == "$LAST_MD5" ]
+  then
+    echo "No need to upload; no database content change"
+    exit 0
+  fi
+fi
+
+bzip2 -c $OUTPUT_FILE > "$OUTPUT_FILE.bz2"
+echo "$CURRENT_MD5" > "$LAST_MD5_FILE"
+
+gsutil -m -h "Cache-Control:no-cache" cp -r "$OUTPUT_FILE.bz2" "gs://$BUCKET/"
+
+# Remove temporary files
+rm $OUTPUT_FILE $OUTPUT_FILE.bz2

--- a/aerospike-gcp-backup/aerospike-gcp-backup.sh
+++ b/aerospike-gcp-backup/aerospike-gcp-backup.sh
@@ -13,10 +13,10 @@ if [ "$HOST" == "" ]; then
     HOST=localhost
 fi
 
-OUTPUT_FILE="/tmp/$DB_NAME-dump_$DATE.asb"
+OUTPUT_FILE="/tmp/$NAMESPACE-dump_$DATE.asb"
 
 asbackup --host $HOST --namespace $NAMESPACE --output-file - > $OUTPUT_FILE
-LAST_MD5_FILE="/tmp/$DB_NAME-dump-md5"
+LAST_MD5_FILE="/tmp/$NAMESPACE-dump-md5"
 if [ -f "$LAST_MD5_FILE" ]; then
   CURRENT_MD5=$(md5sum $OUTPUT_FILE | awk '{ print $1 }')
   LAST_MD5=$(cat "$LAST_MD5_FILE")

--- a/aerospike-gcp-backup/aerospike-gcp-backup.sh
+++ b/aerospike-gcp-backup/aerospike-gcp-backup.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-
 DATE=$(date +%Y%m%d_%H%M)
-NAMESPACE=$1
-BUCKET=$2
-HOST=$3
 
 if [ "$NAMESPACE" == "" ]; then
     echo "Namespace required"


### PR DESCRIPTION
This script uses `asbackup` to create a bzip2-compressed Aerospike backup for a specific namespace and upload it to a specified Google Cloud Storage bucket.