### PR TITLE
Remove SQL dump file after backup is complete and uploaded

### DIFF
--- a/psql-gcp-backup/psql-gcp-backup.sh
+++ b/psql-gcp-backup/psql-gcp-backup.sh
@@ -55,5 +55,6 @@ echo "$CURRENT_MD5" > "$LAST_MD5_FILE"
 
 gsutil -m -h "Cache-Control:no-cache" cp -r "$OUTPUT_FILE" "gs://$BUCKET/"
 
-# Remove temporary file
+# Remove temporary files
 rm "$OUTPUT_FILE"
+rm "/tmp/$DB_NAME-dump_$DATE.sql"


### PR DESCRIPTION
Run final `rm` command to remove the SQL dump file after it's been zipped and uploaded.